### PR TITLE
Shorten the one-liner even more

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 * Ractor based solution from [Kush Fanikiso](https://github.com/makushline)
   https://github.com/makushline/rubyconf_2020_raffle_challenge/blob/main/ractor_miner.rb
 * Single line solution:  
-  `ruby -rdigest -e"i,h=ARGV;p [*?a..?z,*0..9].repeated_permutation(5).find{Digest::MD5.base64digest([i,*_1]*'')==h}"`
+  `ruby -rdigest -e"i,h=$*;-[*?a..?z,*0..9].repeated_permutation(5).find{Digest::MD5.base64digest([i,*_1]*'')==h}"`
   which accepts `id` and `digest` as arguments. Example:  
   ```
-  $ time ruby -rdigest -e"i,h=ARGV;p [*?a..?z,*0..9].repeated_permutation(5).find{Digest::MD5.base64digest([i,*_1]*'')==h}" "jeffdill2" "6G8jF+fGMwEjXwc3htjcZw=="
+  $ time ruby -rdigest -e"i,h=$*;-[*?a..?z,*0..9].repeated_permutation(5).find{Digest::MD5.base64digest([i,*_1]*'')==h}" "jeffdill2" "6G8jF+fGMwEjXwc3htjcZw=="
   ["f", 8, "o", "p", 5]
   
   real    0m25.601s

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 * Ractor based solution from [Kush Fanikiso](https://github.com/makushline)
   https://github.com/makushline/rubyconf_2020_raffle_challenge/blob/main/ractor_miner.rb
 * Single line solution:  
-  `ruby -rdigest -e"i,h=$*;-[*?a..?z,*0..9].repeated_permutation(5).find{Digest::MD5.base64digest([i,*_1]*'')==h}"`
+  `ruby -rdigest -e'i,h=\$*;-[*?a..?z,*0..9].repeated_permutation(5).find{Digest::MD5.base64digest([i,*_1]*"")==h}'`
   which accepts `id` and `digest` as arguments. Example:  
   ```
-  $ time ruby -rdigest -e"i,h=$*;-[*?a..?z,*0..9].repeated_permutation(5).find{Digest::MD5.base64digest([i,*_1]*'')==h}" "jeffdill2" "6G8jF+fGMwEjXwc3htjcZw=="
-  ["f", 8, "o", "p", 5]
+  $ time ruby -rdigest -e'i,h=$*;-[*?a..?z,*0..9].repeated_permutation(5).find{Digest::MD5.base64digest([i,*_1]*"")==h}' "jeffdill2" "6G8jF+fGMwEjXwc3htjcZw=="
+  -e:1:in `<main>': undefined method `-@' for ["f", 8, "o", "p", 5]:Array (NoMethodError)
   
   real    0m25.601s
   user    0m25.572s

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 * Ractor based solution from [Kush Fanikiso](https://github.com/makushline)
   https://github.com/makushline/rubyconf_2020_raffle_challenge/blob/main/ractor_miner.rb
 * Single line solution:  
-  `ruby -rdigest -e'i,h=\$*;-[*?a..?z,*0..9].repeated_permutation(5).find{Digest::MD5.base64digest([i,*_1]*"")==h}'`
+  `ruby -rdigest -e'i,h=$*;-[*?a..?z,*0..9].repeated_permutation(5).find{Digest::MD5.base64digest([i,*_1]*"")==h}'`
   which accepts `id` and `digest` as arguments. Example:  
   ```
   $ time ruby -rdigest -e'i,h=$*;-[*?a..?z,*0..9].repeated_permutation(5).find{Digest::MD5.base64digest([i,*_1]*"")==h}' "jeffdill2" "6G8jF+fGMwEjXwc3htjcZw=="


### PR DESCRIPTION
- Use `$*` instead of `ARGV`, and
- Remove `p ` in favor of `-` which raises an exception that still prints the correct raffle letters. Thanks to @sambostock for this optimization.